### PR TITLE
fix(argus.db.testrun): Wait until heartbeat thread shuts down

### DIFF
--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -524,6 +524,7 @@ class TestRun:
         return False
 
     def shutdown(self):
+        self._log.info("Shutting down cluster connection...")
         self.argus.cluster.shutdown()
 
     @property
@@ -564,7 +565,10 @@ class TestRunWithHeartbeat(TestRun):
             self._log.info("Sending heartbeat...")
             self.heartbeat = time.time()
             self.save()
+        self._log.info("Heartbeat exit")
 
     def shutdown(self):
         self._shutdown_event.set()
+        self._log.info("Waiting for the heartbeat thread to exit...")
+        self._thread.join()
         super().shutdown()

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -576,8 +576,8 @@ class TestRunWithHeartbeat(TestRun):
         if self._thread.is_alive():
             self._log.warning("Heartbeat thread was not able to shut down correctly. Stack trace:")
             # pylint: disable=protected-access
-            stack_trace = traceback.extract_stack(sys._current_frames(
-            )[self._thread.ident])
+            current_threads = sys._current_frames()
+            stack_trace = traceback.extract_stack(current_threads[self._thread.ident])
             self._log.warning(
                 "\n".join([f'#{lineno:3} : {line:50}: {fname}' for fname, lineno, _, line in stack_trace]))
         super().shutdown()

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -1,5 +1,7 @@
 import logging
 import time
+import traceback
+import sys
 import threading
 from dataclasses import asdict, is_dataclass, fields, Field, dataclass
 from typing import Any
@@ -524,7 +526,7 @@ class TestRun:
         return False
 
     def shutdown(self):
-        self._log.info("Shutting down cluster connection...")
+        self._log.debug("Shutting down cluster connection...")
         self.argus.cluster.shutdown()
 
     @property
@@ -565,10 +567,17 @@ class TestRunWithHeartbeat(TestRun):
             self._log.info("Sending heartbeat...")
             self.heartbeat = time.time()
             self.save()
-        self._log.info("Heartbeat exit")
+        self._log.debug("Heartbeat exit")
 
     def shutdown(self):
         self._shutdown_event.set()
-        self._log.info("Waiting for the heartbeat thread to exit...")
-        self._thread.join()
+        self._log.debug("Waiting for the heartbeat thread to exit...")
+        self._thread.join(timeout=self.heartbeat_interval + 10)
+        if self._thread.is_alive():
+            self._log.warning("Heartbeat thread was not able to shut down correctly. Stack trace:")
+            # pylint: disable=protected-access
+            stack_trace = traceback.extract_stack(sys._current_frames(
+            )[self._thread.ident])
+            self._log.warning(
+                "\n".join([f'#{lineno:3} : {line:50}: {fname}' for fname, lineno, _, line in stack_trace]))
         super().shutdown()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='argus',
-    version='0.3.4',
+    version='0.3.5',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_threaded_test_run.py
+++ b/tests/test_threaded_test_run.py
@@ -9,12 +9,15 @@ from argus.db.interface import ArgusDatabase
 LOGGER = logging.getLogger(__name__)
 
 
-def test_heartbeat_thread(completed_testrun: TestRunInfo, mock_cluster: ArgusDatabase, monkeypatch: pytest.MonkeyPatch):
-    class FakeCursor:
-        @staticmethod
-        def one():
-            return True
+class FakeCursor:
+    # pylint: disable=too-few-public-methods
+    @staticmethod
+    def one():
+        return True
 
+
+def test_heartbeat_thread(completed_testrun: TestRunInfo, mock_cluster: ArgusDatabase, monkeypatch: pytest.MonkeyPatch):
+    # pylint: disable=unused-argument
     monkeypatch.setattr(MockSession, "MOCK_RESULT_SET", FakeCursor())
     test_id = uuid4()
     test_run = TestRunWithHeartbeat(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
@@ -22,7 +25,7 @@ def test_heartbeat_thread(completed_testrun: TestRunInfo, mock_cluster: ArgusDat
 
     old_ts = test_run.heartbeat
     for i in range(1, 4):
-        LOGGER.info(f"Checking ts #{i}")
+        LOGGER.info("Checking timestamp %s", i)
         time.sleep(5)
         new_ts = test_run.heartbeat
         assert new_ts != old_ts
@@ -30,4 +33,16 @@ def test_heartbeat_thread(completed_testrun: TestRunInfo, mock_cluster: ArgusDat
 
     test_run.shutdown()
     time.sleep(0.5)
-    assert not test_run._thread.is_alive()
+    assert not test_run._thread.is_alive()  # pylint: disable=protected-access
+
+
+def test_heartbeat_thread_shutdown(completed_testrun: TestRunInfo, mock_cluster: ArgusDatabase,
+                                   monkeypatch: pytest.MonkeyPatch):
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(MockSession, "MOCK_RESULT_SET", FakeCursor())
+    test_id = uuid4()
+    test_run = TestRunWithHeartbeat(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
+                                    run_info=completed_testrun, heartbeat_interval=15)
+
+    test_run.shutdown()
+    assert not test_run._thread.is_alive()  # pylint: disable=protected-access


### PR DESCRIPTION
This makes sure that TestRun.shutdown method blocks until the heartbeat
thread exits, ensuring that it doesn't end up in a partially finished
state.

[Trello](https://trello.com/c/TRMUFXJw/4137-argus-keeps-threads-open-at-the-end-of-sct-test)