### PR TITLE
refactor(argus.db): Drop all clustering keys from TestRun

### DIFF
--- a/argus/db/interface.py
+++ b/argus/db/interface.py
@@ -140,8 +140,9 @@ class ArgusDatabase:
         clustering_column_def = ", ".join(clustering_columns)
 
         self._table_keys[table_name] = primary_keys_info
-
-        query = "CREATE TABLE IF NOT EXISTS {table_name}({columns}, PRIMARY KEY ({partition_key}, {clustering_cols}))"
+        primary_key_def = f"{partition_key_def}, {clustering_column_def}" if len(
+            clustering_column_def) > 0 else partition_key_def
+        query = "CREATE TABLE IF NOT EXISTS {table_name}({columns}, PRIMARY KEY ({primary_key}))"
         columns_query = []
         for column in column_info.values():
             if mapped_type := self.is_native_type(column.type):
@@ -157,8 +158,7 @@ class ArgusDatabase:
             columns_query.append(column_query)
 
         columns_query = ", ".join(columns_query)
-        completed_query = query.format(table_name=table_name, columns=columns_query, partition_key=partition_key_def,
-                                       clustering_cols=clustering_column_def)
+        completed_query = query.format(table_name=table_name, columns=columns_query, primary_key=primary_key_def)
         self.log.debug("About to execute: \"%s\"", completed_query)
         self.session.execute(query=completed_query)
         self.initialized_tables[table_name] = True

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -368,6 +368,10 @@ class TestRun:
             self.argus = argus_interface
 
     @classmethod
+    def table_name(cls) -> str:
+        return cls._TABLE_NAME
+
+    @classmethod
     def from_db_row(cls, row, config: BaseConfig = None):
         if not cls._IS_TABLE_INITIALIZED:
             cls.init_own_table(config)

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -341,14 +341,9 @@ class TestRun:
     }
     PRIMARY_KEYS = {
         "id": (UUID, "partition"),
-        "release_name": (str, "clustering"),  # release version, e.g. 4.5rc5
-        "name": (str, "clustering"),  # test case name, e.g longevity-test-500gb-4h
-        "group": (str, "clustering"),  # test group, e.g longevity_test
-        "assignee": (str, "clustering"),  # who is assigned to this test, e.g. bentsi
-        "start_time": (int, "clustering"),  # start time of the test, unix timestamp
     }
     _USING_RUNINFO = TestRunInfo
-    _TABLE_NAME = "test_runs"
+    _TABLE_NAME = "test_runs_v2"
     _IS_TABLE_INITIALIZED = False
     _ARGUS_DB_INTERFACE = None
     _log = logging.getLogger('TestRun')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='argus',
-    version='0.3.5',
+    version='0.4.0',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_db_interface.py
+++ b/tests/test_db_interface.py
@@ -52,7 +52,7 @@ def test_interface_schema_init(mock_cluster, preset_test_details_schema, simple_
                                              "build_job_name varchar , build_job_url varchar , start_time varint ," \
                                              " yaml_test_duration varint , config_files list<varchar> , " \
                                              "packages list<frozen<PackageVersion>> , end_time varint , " \
-                                             "PRIMARY KEY (id, ))"
+                                             "PRIMARY KEY (id))"
 
 
 def test_interface_init_table_twice(mock_cluster, preset_test_details_schema, simple_primary_key,

--- a/tests/test_e2e_argus.py
+++ b/tests/test_e2e_argus.py
@@ -19,7 +19,7 @@ class TestEndToEnd:
 
         test_run.save()
 
-        res = argus_database.fetch(table_name="test_runs", run_id=test_id)
+        res = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
         LOGGER.debug("Fetched: %s", res)
         LOGGER.info("Rebuilding object...")
 
@@ -54,7 +54,7 @@ class TestEndToEnd:
         test_run.run_info.resources.detach_resource(resource)
         test_run.save()
 
-        row = argus_database.fetch(table_name="test_runs", run_id=test_id)
+        row = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
 
         rebuilt_testrun = TestRun.from_db_row(row)
 


### PR DESCRIPTION
This is a migration commit, it requires a migration to be performed.
Due to this fact, the _TABLE_NAME was changed to test_runs_v2 and
migration was performed to migrate old data.