### PR TITLE
fix(argus_web): Force UTC Timezone and ISO format in all timestamps

### DIFF
--- a/argus/backend/argus_service.py
+++ b/argus/backend/argus_service.py
@@ -793,7 +793,7 @@ class ArgusService:
             groups_by_schedule_id = {group.schedule_id: group for group in scheduled_groups}
             schedules = ArgusReleaseSchedule.filter(
                 release=release, schedule_id__in=tuple(groups_by_schedule_id.keys())).all()
-            today = datetime.datetime.now()
+            today = datetime.datetime.utcnow()
             this_monday = today - datetime.timedelta(today.weekday() + 1)
             next_week = this_monday + datetime.timedelta(8)
             valid_schedules = [
@@ -896,7 +896,7 @@ class ArgusService:
             user.username = user_info.get("login")
             user.email = email_info[-1].get("email")
             user.full_name = user_info.get("name")
-            user.registration_date = datetime.datetime.now()
+            user.registration_date = datetime.datetime.utcnow()
             user.roles = ["ROLE_USER"]
             temp_password = base64.encodebytes(
                 os.urandom(48)).decode("ascii").strip()

--- a/argus/backend/assets/Github/GithubIssue.svelte
+++ b/argus/backend/assets/Github/GithubIssue.svelte
@@ -38,7 +38,7 @@
         <div class="me-2 text-truncate" style="width: 20em;" title="{issue.title}"><Fa icon={faGithub}/> <a href="{issue.url}">{issue.title}</a></div>
         <div class="text-muted me-auto">{issue.repo}#{issue.issue_number}</div>
         {#if Object.keys(users).length > 0}
-            <div class="text-muted me-2" title={new Date(issue.added_on).toLocaleString()}>Added by {users[issue.user_id].username}</div>
+            <div class="text-muted me-2" title={new Date(issue.added_on).toISOString()}>Added by {users[issue.user_id].username}</div>
         {/if}
         <div class="text-muted"><a class="link-secondary" href="/test_run/{issue.run_id}">Run<Fa icon={faExternalLinkSquareAlt}/></a></div>
     </div>

--- a/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
@@ -108,7 +108,7 @@
                                 <div class="ms-auto text-muted">
                                     {new Date(
                                         event.created_at
-                                    ).toLocaleString()}
+                                    ).toISOString()}
                                 </div>
                                 <div class="ms-2 text-muted">
                                     <a

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -45,7 +45,7 @@
                         <span class="text-muted" style="font-size: 0.75em"
                             >{new Date(
                                 test.start_time * 1000
-                            ).toLocaleString()}</span
+                            ).toISOString()}</span
                         >
                     </div>
                     <button

--- a/argus/backend/assets/TestRun/ActivityTab.svelte
+++ b/argus/backend/assets/TestRun/ActivityTab.svelte
@@ -71,7 +71,7 @@
                     <small class="text-muted"
                         >{new Date(
                             event.created_at
-                        ).toLocaleString()}</small
+                        ).toISOString()}</small
                     >
                         </p>
                 </div>

--- a/argus/backend/assets/TestRun/NemesisData.svelte
+++ b/argus/backend/assets/TestRun/NemesisData.svelte
@@ -42,13 +42,13 @@
                             <li>
                                 Start Time: {new Date(
                                     nemesis.start_time * 1000
-                                ).toLocaleString()}
+                                ).toISOString()}
                             </li>
                             {#if nemesis.end_time != 0}
                                 <li>
                                     End Time: {new Date(
                                         nemesis.end_time * 1000
-                                    ).toLocaleString()}
+                                    ).toISOString()}
                                 </li>
                                 <li>
                                     Duration: {nemesis.duration}

--- a/argus/backend/assets/TestRun/ResourcesInfo.svelte
+++ b/argus/backend/assets/TestRun/ResourcesInfo.svelte
@@ -57,7 +57,7 @@
                                                 Created at {new Date(
                                                     resource.instance_info
                                                         .creation_time * 1000
-                                                ).toLocaleString()}
+                                                ).toISOString()}
                                             </li>
                                             {#if resource.instance_info.termination_time != 0}
                                                 <li>
@@ -65,7 +65,7 @@
                                                         resource.instance_info
                                                             .termination_time *
                                                             1000
-                                                    ).toLocaleString()}
+                                                    ).toISOString()}
                                                 </li>
                                                 <li>
                                                     Termination reason: {resource.instance_info.termination_reason.split(

--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -214,7 +214,7 @@
                         type="button"
                         title={new Date(
                             test_run.end_time * 1000
-                        ).toLocaleString()}
+                        ).toISOString()}
                         data-bs-toggle="dropdown"
                     >
                         {test_run.status.toUpperCase()}

--- a/argus/backend/assets/TestRun/TestRunComments.svelte
+++ b/argus/backend/assets/TestRun/TestRunComments.svelte
@@ -124,7 +124,7 @@
                             <small class="text-muted"
                                 >{new Date(
                                     comment.posted_at * 1000
-                                ).toLocaleString()}</small
+                                ).toISOString()}</small
                             >
                         </p>
                     </div>

--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -79,13 +79,13 @@
                 <li>
                     Start Time: {new Date(
                         test_run.start_time * 1000
-                    ).toLocaleString()}
+                    ).toISOString()}
                 </li>
                 {#if test_run.end_time != -1}
                     <li>
                         End Time: {new Date(
                             test_run.end_time * 1000
-                        ).toLocaleString()}
+                        ).toISOString()}
                     </li>
                 {/if}
                 <li>

--- a/argus/backend/assets/WorkArea/Test.svelte
+++ b/argus/backend/assets/WorkArea/Test.svelte
@@ -69,7 +69,7 @@
             <div class="col-10 overflow-hidden">
                 <div>{test.pretty_name ?? test.name}</div>
                 {#if startTime > 1}
-                <div class="text-muted" style="font-size: 0.75em">{new Date(startTime * 1000).toLocaleString()}</div>
+                <div class="text-muted" style="font-size: 0.75em">{new Date(startTime * 1000).toISOString()}</div>
                 {/if}
             </div>
             <div class="col-1 text-center">

--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -55,7 +55,7 @@
             <div>{testInfo} ({releaseName})</div>
             {#if runs.length > 0}
             <div class="ms-auto flex-fill text-end">Last run: #{runs[0].build_number}</div>
-            <div class="mx-2">Date: {new Date(runs[0].start_time * 1000).toLocaleString()}</div>
+            <div class="mx-2">Date: {new Date(runs[0].start_time * 1000).toISOString()}</div>
             {/if}
 
         </button>


### PR DESCRIPTION
This commit improves user experience when investigating runs, enforcing
that every timestamp uses UTC timezone and ISO format

[Trello](https://trello.com/c/P01aWk6E/4407-timestamps-should-be-consistent-use-utc-for-all)