### PR TITLE
feature(WorkArea.svelte): Ability to remove runs from work area

### DIFF
--- a/argus/backend/assets/Stores/TestRunsSubscriber.js
+++ b/argus/backend/assets/Stores/TestRunsSubscriber.js
@@ -32,6 +32,9 @@ TestRunsEventListener.subscribe(value => {
                 });
             }, 150);
             break;
+        case "unsubscribe":
+            delete runCollection[value.id];
+            break;
         default:
             break;
     }

--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -65,7 +65,7 @@
         { round: true }
     );
 
-    polledTestRuns.subscribe((data) => {
+    const polledRunUnsub = polledTestRuns.subscribe((data) => {
         test_run = data[id] ?? test_run;
     });
 
@@ -211,6 +211,12 @@
 
     onDestroy(() => {
         if (clockInterval) clearInterval(clockInterval);
+        polledRunUnsub();
+        testRunStore.update((store) => {
+            return store.filter((run) => {
+                return run != test_run.id;
+            });
+        });
     });
 </script>
 

--- a/argus/backend/assets/WorkArea/RunGroup.svelte
+++ b/argus/backend/assets/WorkArea/RunGroup.svelte
@@ -13,6 +13,7 @@
     };
     export let filtered = false;
     export let assigneeList = [];
+    export let runs = {};
 
     const groupStatsTemplate = {
         created: 0,
@@ -166,7 +167,9 @@
                             {test}
                             filtered={isFiltered(test.name)}
                             group={group.name}
+                            bind:runs={runs}
                             on:testRunRequest
+                            on:testRunRemove
                         />
                     {:else}
                         <div class="row">

--- a/argus/backend/assets/WorkArea/RunRelease.svelte
+++ b/argus/backend/assets/WorkArea/RunRelease.svelte
@@ -10,6 +10,7 @@
         pretty_name: "undefined",
     };
     export let filtered = false;
+    export let runs = {};
     let fetched = false;
     const releaseStatsDefault = {
         created: 0,
@@ -163,7 +164,9 @@
                         filtered={isFiltered(group.pretty_name ?? group.name)}
                         parent="#accordionGroups{release.name}"
                         assigneeList={assigneeList?.groups[group.name] ?? []}
+                        bind:runs={runs}
                         on:testRunRequest
+                        on:testRunRemove
                     />
                 {:else}
                     <div class="row">

--- a/argus/backend/assets/WorkArea/TestRunsPanel.svelte
+++ b/argus/backend/assets/WorkArea/TestRunsPanel.svelte
@@ -2,6 +2,7 @@
     import { Base64 } from "js-base64";
     import TestRuns from "./TestRuns.svelte";
     export let test_runs = {};
+    export let workAreaAttached = false;
     let serializedState = "";
     $: serializedState = Base64.encode(JSON.stringify(test_runs), true);
     let filterStringRuns = "";
@@ -19,11 +20,13 @@
     <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { test_runs = test_runs }}>
 </div>
 <div class="accordion mb-2" id="accordionTestRuns">
-    {#each Object.keys(test_runs) as test_run_id}
+    {#each Object.entries(test_runs) as [id, data] (id)}
         <TestRuns
-            data={test_runs[test_run_id]}
+            {data}
             parent="#accordionTestRuns"
-            filtered={isFiltered(test_runs[test_run_id].test, filterStringRuns)}
+            filtered={isFiltered(data.test, filterStringRuns)}
+            removableRuns={workAreaAttached}
+            on:testRunRemove
         />
     {/each}
 </div>


### PR DESCRIPTION
This commit adds a couple of ways to remove unneeded runs, either by
clicking trashcan button on the runs collapse itself, or by clicking on
the test name again in the work area sidebar. Additionally, this commit
will add resource release handling to prevent memory leaks when runs are
removed from work area.

[Trello](https://trello.com/c/8AEjgcwI/4383-add-ability-to-remove-the-test-from-the-working-area)

Must be merged before #17 