### PR TITLE
fix(TestRunsPanel.svelte): Order runs in reverse insertion order 

### DIFF
--- a/argus/backend/assets/WorkArea/TestRunsPanel.svelte
+++ b/argus/backend/assets/WorkArea/TestRunsPanel.svelte
@@ -20,7 +20,7 @@
     <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { test_runs = test_runs }}>
 </div>
 <div class="accordion mb-2" id="accordionTestRuns">
-    {#each Object.entries(test_runs) as [id, data] (id)}
+    {#each Object.entries(test_runs).reverse() as [id, data] (id)}
         <TestRuns
             {data}
             parent="#accordionTestRuns"


### PR DESCRIPTION
This commit changes the display behaviour of runs being added to the
work panel to use reverse order, so that the newest test is going to be
displayed on top of the stack, instead of the bottom

[Trello](https://trello.com/c/vKbZnXv3/4492-show-test-details-on-top-when-clicking-on-the-test-in-the-sidebar)

Must be merged after #16