### PR TITLE
fix(Alert.svelte): Remove "success" sendMessage calls

### DIFF
--- a/argus/backend/assets/Debug/FlashDebugComponent.svelte
+++ b/argus/backend/assets/Debug/FlashDebugComponent.svelte
@@ -11,7 +11,7 @@
     id="storeSuccess"
     class="btn btn-success"
     on:click={() => {
-        sendMessage("success", "Wowe it works.");
+
     }}>Store Success</button
 >
 <button

--- a/argus/backend/assets/Github/GithubIssues.svelte
+++ b/argus/backend/assets/Github/GithubIssues.svelte
@@ -46,7 +46,7 @@
             });
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
-                sendMessage("success", "Attached an issue successfully.");
+
                 fetchIssues();
             } else {
                 throw apiJson;

--- a/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
+++ b/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
@@ -90,7 +90,7 @@
             if (apiJson.status === "ok") {
                 handleClearGroups();
                 fetchSchedules();
-                sendMessage("success", "Added new schedule!");
+
             } else {
                 throw apiJson;
             }
@@ -127,7 +127,7 @@
             if (apiJson.status === "ok") {
                 fetchSchedules();
                 handleClearGroups();
-                sendMessage("success", "Schedule deleted, refreshing...");
+
             } else {
                 throw apiJson;
             }

--- a/argus/backend/assets/TestRun/IssueTemplate.svelte
+++ b/argus/backend/assets/TestRun/IssueTemplate.svelte
@@ -31,7 +31,7 @@
 
     const copyTemplateToClipboard = function () {
         navigator.clipboard.writeText(issueTemplateText);
-        sendMessage("success", "Copied to clipboard.");
+
     };
 
     let scyllaServerPackage = findScyllaServerPackage();

--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -133,17 +133,6 @@
             let apiJson = await apiResponse.json();
             console.log(apiJson);
             if (apiJson.status === "ok") {
-                if (new_assignee != "none-none-none") {
-                    sendMessage(
-                        "success",
-                        `Successfully changed assignee to "${users[new_assignee].username}"`
-                    );
-                } else {
-                    sendMessage(
-                        "success",
-                        `Successfully cleared assignee from a run`
-                    );
-                }
                 fetchTestRunData();
             } else {
                 throw apiJson;
@@ -179,10 +168,6 @@
             let apiJson = await apiResponse.json();
             console.log(apiJson);
             if (apiJson.status === "ok") {
-                sendMessage(
-                    "success",
-                    `Successfully changed status from "${test_run.status}" to "${newStatus}"`
-                );
                 fetchTestRunData();
             } else {
                 throw apiJson;

--- a/argus/backend/assets/TestRun/TestRunComments.svelte
+++ b/argus/backend/assets/TestRun/TestRunComments.svelte
@@ -74,7 +74,7 @@
             console.log(apiJson);
             if (apiJson.status === "ok") {
                 comments = apiJson.response;
-                sendMessage("success", "Successfully posted a comment!")
+
                 fetching = false;
             } else {
                 throw apiJson;

--- a/argus/backend/assets/WorkArea/WorkArea.svelte
+++ b/argus/backend/assets/WorkArea/WorkArea.svelte
@@ -84,7 +84,7 @@
         };
         test_runs = test_runs;
         stateUpdater();
-        sendMessage("success", `Successfuly added ${event.detail.test} to the work area`)
+
     };
 
     onMount(() => {


### PR DESCRIPTION
This removes all "success" alert toasts, as they are not needed and
actively harm user experience

[Trello](https://trello.com/c/s4FYuzh0/4490-remove-success-notifications-popups)