### PR TITLE
fix(TestRunInfo.svelte): Open build job url in a new window

### DIFF
--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -98,9 +98,13 @@
                         "Unknown, probably jenkins"}
                 </li>
                 <li>
-                    <span class="fw-bold">Build Job:</span> <a href={test_run.build_job_url}
-                        >{test_run.build_job_name}</a
+                    <span class="fw-bold">Build Job:</span>
+                    <a
+                        href={test_run.build_job_url}
+                        target="_blank"
                     >
+                        {test_run.build_job_name}
+                    </a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/OJ8B0R8e/4384-link-to-build-job-should-be-opened-in-new-tab)

Must be merged after #19