### PR TITLE
improvement(TestRuns.svelte): Better selected run indicator

### DIFF
--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -70,7 +70,7 @@
                 {#each runs as run}
                     <div class="me-2 d-inline-block">
                         <button
-                            class:border-active={clickedTestRuns[run.id]}
+                            class:active={clickedTestRuns[run.id]}
                             class="btn {StatusButtonCSSClassMap[run.status]}"
                             type="button"
                             data-bs-toggle="collapse"
@@ -112,8 +112,8 @@
         cursor: help;
     }
 
-    .border-active {
-        border: 3px solid rgb(84, 192, 255);
+    .active::before {
+        content: "🠶 ";
     }
 
 </style>


### PR DESCRIPTION
Changes blue outline indicator around a run to instead be darker
shade of the current run status and inserts a finger post arrow to
provide a good indicator of a selected run

[Trello](https://trello.com/c/udOI67XN/4496-use-focus-instead-of-outline-when-clicking-on-multiple-testruns)
![How it looks](https://i.komachi.sh/34k22gzw6g.png)