### PR TITLE
feature(db_types): Add build_id field to PackageVersion

### DIFF
--- a/argus/backend/assets/TestRun/IssueTemplate.svelte
+++ b/argus/backend/assets/TestRun/IssueTemplate.svelte
@@ -70,7 +70,7 @@
 ## Installation details
 
 
-Scylla version (or git commit hash): `{scyllaServerPackage.version} with build-id {scyllaServerPackage.revision_id}`
+Scylla version (or git commit hash): `{scyllaServerPackage.version}-{scyllaServerPackage.date}.{scyllaServerPackage.revision_id} with build-id {scyllaServerPackage.build_id}`
 
 Cluster size: {test_run.cloud_setup.db_node.node_amount} nodes ({test_run.cloud_setup.db_node.instance_type})
 

--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -33,7 +33,7 @@
                     {test_run.id}
                 </li>
                 <li>
-                    <span class="fw-bold">Start Time:</span> 
+                    <span class="fw-bold">Start Time:</span>
                     {timestampToISODate(
                         test_run.start_time * 1000,
                         true
@@ -41,7 +41,7 @@
                 </li>
                 {#if test_run.end_time != -1}
                     <li>
-                        <span class="fw-bold">End Time:</span> 
+                        <span class="fw-bold">End Time:</span>
                         {timestampToISODate(
                             test_run.end_time * 1000,
                             true
@@ -77,11 +77,19 @@
                 <li>
                     <span class="fw-bold">AMI ImageId:</span> {test_run.cloud_setup.db_node.image_id}
                 </li>
+                <!-- Scylla v4.5.3-0.20211223.c8f14886d (ami-0df0fbe3daf5ad63d) -->
+                {#if test_run.packages[0]}
                 <li>
-                    <span class="fw-bold">Scylla Version:</span> {test_run.packages[0]?.version ??
-                        "Unknown yet"}/{test_run.packages[0]?.revision_id ??
-                        "Unknown yet"}
+                    <span class="fw-bold">Scylla Version:</span>
+                    {test_run.packages[0]?.version}-{test_run.packages[0]?.date}.{test_run.packages[0]?.revision_id}
                 </li>
+                    {#if test_run.packages[0]?.build_id}
+                        <li>
+                            <span class="fw-bold">Build Id:</span>
+                            {test_run.packages[0]?.build_id}
+                        </li>
+                    {/if}
+                {/if}
                 <li>
                     <span class="fw-bold">Instance Type:</span> {test_run.cloud_setup.db_node.instance_type}
                 </li>

--- a/argus/db/db_types.py
+++ b/argus/db/db_types.py
@@ -43,10 +43,13 @@ class PackageVersion(ArgusUDTBase):
     version: str
     date: str
     revision_id: str
+    build_id: str = ""
+    _typename = "PackageVersion_v2"
 
     @classmethod
     def from_db_udt(cls, udt):
-        return cls(name=udt.name, version=udt.version, date=udt.date, revision_id=udt.revision_id)
+        return cls(name=udt.name, version=udt.version,
+                   date=udt.date, revision_id=udt.revision_id, build_id=udt.build_id)
 
 
 class NemesisStatus(str, Enum):

--- a/argus/db/db_types.py
+++ b/argus/db/db_types.py
@@ -1,7 +1,7 @@
 import re
 import time
 from enum import Enum
-from typing import Any, Union, Type, TypeVar
+from typing import Any, Union, Type, TypeVar, Optional
 from pydantic.dataclasses import dataclass
 from pydantic import validator, ValidationError
 
@@ -43,7 +43,7 @@ class PackageVersion(ArgusUDTBase):
     version: str
     date: str
     revision_id: str
-    build_id: str = ""
+    build_id: Optional[str] = ""
     _typename = "PackageVersion_v2"
 
     @classmethod

--- a/argus/db/interface.py
+++ b/argus/db/interface.py
@@ -4,7 +4,7 @@ import json
 from uuid import UUID
 from hashlib import sha1
 from dataclasses import fields as dataclass_fields
-from typing import KeysView, Union, Any, get_args as get_type_args, get_origin as get_type_origin
+from typing import KeysView, Union, Optional, Any, get_args as get_type_args, get_origin as get_type_origin
 from types import GenericAlias
 
 import cassandra.cluster
@@ -42,6 +42,7 @@ class ArgusDatabase:
         float: cassandra.cqltypes.FloatType.typename,
         str: cassandra.cqltypes.VarcharType.typename,
         UUID: cassandra.cqltypes.UUIDType.typename,
+        Optional[str]: cassandra.cqltypes.VarcharType.typename,
     }
 
     _INSTANCE: Union['ArgusDatabase', Any] = None

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -345,7 +345,7 @@ class TestRun:
         "id": (UUID, "partition"),
     }
     _USING_RUNINFO = TestRunInfo
-    _TABLE_NAME = "test_runs_v2"
+    _TABLE_NAME = "test_runs_v3"
     _IS_TABLE_INITIALIZED = False
     _ARGUS_DB_INTERFACE = None
 

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 
 setup(
     name='argus',
-    version='0.5.1',
+    version='0.5.2-rc1',
     packages=["argus.db", "argus.backend"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=open(os.path.join(base_dir,'requirements.txt')).readlines(),
-    test_requires=open(os.path.join(base_dir,'requirements_test.txt')).readlines(),
+    install_requires=open(os.path.join(base_dir, 'requirements.txt')).readlines(),
+    test_requires=open(os.path.join(base_dir, 'requirements_test.txt')).readlines(),
 
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def preset_test_details():
                           build_job_url="https://job.tld/1", start_time=1600000000, yaml_test_duration=120,
                           config_files=["some-test.yaml"],
                           packages=[PackageVersion(name="package-server", version="1.0", date="2021-10-01",
-                                                   revision_id="dfcedb3")])
+                                                   revision_id="dfcedb3", build_id="dfeeeffffff330fddd")])
     return details
 
 
@@ -143,6 +143,7 @@ def preset_test_details_serialized():
             "version": "1.0",
             "date": "2021-10-01",
             "revision_id": "dfcedb3",
+            "build_id": "dfeeeffffff330fddd",
         }],
         "end_time": -1,
     }

--- a/tests/test_db_interface.py
+++ b/tests/test_db_interface.py
@@ -51,7 +51,7 @@ def test_interface_schema_init(mock_cluster, preset_test_details_schema, simple_
                                              "(name varchar , scm_revision_id varchar , started_by varchar , " \
                                              "build_job_name varchar , build_job_url varchar , start_time varint ," \
                                              " yaml_test_duration varint , config_files list<varchar> , " \
-                                             "packages list<frozen<PackageVersion>> , end_time varint , " \
+                                             "packages list<frozen<PackageVersion_v2>> , end_time varint , " \
                                              "PRIMARY KEY (id))"
 
 

--- a/tests/test_testinfo.py
+++ b/tests/test_testinfo.py
@@ -39,8 +39,8 @@ def test_details_ctor_from_named_tuple(preset_test_details):
     ResultSet = namedtuple("Row",
                            ["name", "scm_revision_id", "started_by", "build_job_name", "build_job_url", "start_time",
                             "yaml_test_duration", "config_files", "packages", "end_time"])
-    PackageMapped = namedtuple("PackageMapped", ["name", "version", "date", "revision_id"])
-    package = PackageMapped("package-server", "1.0", "2021-10-01", "dfcedb3")
+    PackageMapped = namedtuple("PackageMapped", ["name", "version", "date", "revision_id", "build_id"])
+    package = PackageMapped("package-server", "1.0", "2021-10-01", "dfcedb3", "dfeeeffffff330fddd")
     row = ResultSet(preset_test_details.name, preset_test_details.scm_revision_id, preset_test_details.started_by,
                     preset_test_details.build_job_name, preset_test_details.build_job_url,
                     preset_test_details.start_time,


### PR DESCRIPTION
Add missing build_id field into PackageVersion UDT that tracks build id
of the package being submitted.

[Trello](https://trello.com/c/5bpcgROU/4494-show-correct-scylla-version)

![image](https://user-images.githubusercontent.com/7761415/150127650-101c424f-ce4a-4ec7-847c-0df284ec952f.png)
