### PR TITLE
fix(TestRuns.svelte): Use btn-close instead of fas-Trash icon

### DIFF
--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -3,8 +3,6 @@
     import { v4 as uuidv4 } from "uuid";
     import { runStore, polledRuns, TestRunsEventListener } from "../Stores/TestRunsSubscriber";
     import { StatusButtonCSSClassMap, StatusBackgroundCSSClassMap } from "../Common/TestStatus";
-    import Fa from "svelte-fa";
-    import { faTrash } from "@fortawesome/free-solid-svg-icons"
     import { timestampToISODate } from "../Common/DateUtils";
     import TestRun from "../TestRun/TestRun.svelte";
     export let data = {};
@@ -87,10 +85,10 @@
             {#if removableRuns}
             <div class="mx-2 text-end" class:flex-fill={runs.length == 0}>
                 <div
-                    class="d-inline-block btn btn-danger"
+                    class="d-inline-block btn btn-close"
+                    role="button"
                     on:click={() => { dispatch("testRunRemove", { runId: myId })}}
                 >
-                    <Fa icon={faTrash}/>
                 </div>
             </div>
             {/if}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7761415/150128533-e86f7809-5e8a-4124-9175-7c2c2ebfc11c.png)
[Trello](https://trello.com/c/L9X4nNzn/4542-replace-trash-icon-by-x-close-button)