### PR TITLE
fix(TestRun.svelte): Use light background for build number indicator

### DIFF
--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -214,7 +214,7 @@
                 <div class="col-2 py-2">
                     <div class="d-flex">
                         <a
-                            class="btn btn-dark me-2"
+                            class="btn btn-light me-2"
                             href="/test_run/{id}"
                             target="_blank">#{build_number}</a
                         >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7761415/150128971-101a8cfe-cadb-4be9-b311-1bb1dd68358b.png)
[Trello](https://trello.com/c/AetV0ROs/4533-make-build-id-button-grayish-instead-of-black)