### PR TITLE
feature(IssueTemplate.svelte): Raw text and Separate Preview tab

### DIFF
--- a/argus/backend/assets/TestRun/IssueTemplate.svelte
+++ b/argus/backend/assets/TestRun/IssueTemplate.svelte
@@ -4,7 +4,6 @@
     import { faCopy } from "@fortawesome/free-solid-svg-icons";
     import { parse } from "marked";
     import { onMount } from "svelte";
-    import { sendMessage } from "../Stores/AlertStore";
     let renderedElement;
     let templateElement;
     let issueTemplateText = "";
@@ -25,13 +24,14 @@
               };
     };
 
-    const filterDbNodes = function(resources) {
-        return resources.filter(val => new RegExp(/\-db\-node/).test(val.name));
-    }
+    const filterDbNodes = function (resources) {
+        return resources.filter((val) =>
+            new RegExp(/\-db\-node/).test(val.name)
+        );
+    };
 
     const copyTemplateToClipboard = function () {
         navigator.clipboard.writeText(issueTemplateText);
-
     };
 
     let scyllaServerPackage = findScyllaServerPackage();
@@ -63,10 +63,46 @@
             </div>
             <div id="collapseIssueTemplate-{test_run.id}" class="collapse">
                 <div class="accordion-body">
-                    <pre
-                        bind:this={templateElement}
-                        id="issueTemplateText-{test_run.id}"
-                        class="d-none">
+                    <ul
+                        class="nav nav-tabs"
+                        role="tablist"
+                        id="issuePreviewTabs-{test_run.id}"
+                    >
+                        <li class="nav-item" role="presentation">
+                            <button
+                                class="nav-link active"
+                                id="home-tab"
+                                data-bs-toggle="tab"
+                                data-bs-target="#issueTemplateRaw-{test_run.id}"
+                                type="button"
+                                role="tab"
+                            >
+                                Template
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button
+                                class="nav-link"
+                                id="profile-tab"
+                                data-bs-toggle="tab"
+                                data-bs-target="#issueTemplatePreview-{test_run.id}"
+                                type="button"
+                                role="tab"
+                            >
+                                Preview
+                            </button>
+                        </li>
+                    </ul>
+                    <div class="tab-content border-start border-end border-bottom p-1">
+                        <div
+                            class="tab-pane fade show active"
+                            id="issueTemplateRaw-{test_run.id}"
+                            role="tabpanel"
+                        >
+                            <pre
+                                class="code user-select-all"
+                                bind:this={templateElement}
+                                id="issueTemplateText-{test_run.id}">
 ## Installation details
 
 
@@ -96,11 +132,12 @@ Test config file(s):
 
 
 ## Issue description
-#### &gt;&gt;&gt;&gt;&gt;&gt;&gt;
+
+&gt;&gt;&gt;&gt;&gt;&gt;&gt;
 
 **Your description here...**
 
-#### &lt;&lt;&lt;&lt;&lt;&lt;&lt;
+&lt;&lt;&lt;&lt;&lt;&lt;&lt;
 
 - Restore Monitor Stack command: `$ hydra investigate show-monitor {test_run.id}`
 - Restore monitor on AWS instance using [Jenkins job](https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?test_id={test_run.id})
@@ -113,17 +150,29 @@ Test config file(s):
     - **{log[0]}** - [{log[1]}]({log[1]}){"\n"}
 {:else}
     *No logs captured during this run.*
-
 {/each}
 
 [Jenkins job URL]({test_run.build_job_url})
                             </pre>
-                    <div
-                        bind:this={renderedElement}
-                        id="issueTemplateRendered-{test_run.id}"
-                    />
+                        </div>
+                        <div class="tab-pane fade" id="issueTemplatePreview-{test_run.id}" role="tabpanel">
+                            <div
+                                class="p-2 markdown-body"
+                                bind:this={renderedElement}
+                                id="issueTemplateRendered-{test_run.id}"
+                            />
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<style>
+    .code {
+        font-size: 11pt;
+        padding: 1em;
+        background-color: #f0f0f0;
+    }
+</style>

--- a/argus/backend/assets/argus.js
+++ b/argus/backend/assets/argus.js
@@ -4,5 +4,5 @@ import '@fortawesome/fontawesome-free/js/solid';
 import '@fortawesome/fontawesome-free/js/regular';
 import '@fortawesome/fontawesome-free/js/brands';
 import 'marked';
+import 'github-markdown-css';
 import './argus.css';
-

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "chrono-node": "^2.3.4",
     "css-loader": "^5.2.6",
     "dayjs": "^1.10.7",
+    "github-markdown-css": "^5.1.0",
     "humanize-duration": "^3.27.0",
     "jquery": "^3.6.0",
     "js-base64": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,11 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+github-markdown-css@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/github-markdown-css/-/github-markdown-css-5.1.0.tgz#a96281cd90a8969e3c13b9d3ca6a733a523a00a6"
+  integrity sha512-QLtORwHHtUHhPMHu7i4GKfP6Vx5CWZn+NKQXe+cBhslY1HEt0CTEkP4d/vSROKV0iIJSpl4UtlQ16AD8C6lMug==
+
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"


### PR DESCRIPTION
Raw template display and a preview tab. Clicking on raw template selects whole template

[Trello](https://trello.com/c/Wy6omLhO/4577-make-issue-template-plain-text-markdown)

[Preview](https://user-images.githubusercontent.com/7761415/151020651-1da5fc1d-1001-418c-9ea9-50e175054aca.mp4)


