### PR TITLE
feature(argus.db.cloud_types): Tracking shard amounts on instances 

### DIFF
--- a/argus/backend/assets/TestRun/IssueTemplate.svelte
+++ b/argus/backend/assets/TestRun/IssueTemplate.svelte
@@ -76,7 +76,7 @@ Cluster size: {test_run.cloud_setup.db_node.node_amount} nodes ({test_run.cloud_
 
 Scylla running with shards number (live nodes):
 {#each filterDbNodes(test_run.leftover_resources) as resource}
-    - {resource.name} ({resource.instance_info.public_ip} | {resource.instance_info.private_ip}){"\n"}
+    - {resource.name} ({resource.instance_info.public_ip} | {resource.instance_info.private_ip}) (shards: {resource.instance_info.shards_amount}){"\n"}
 {:else}
     **No resources left at the end of the run**
 {/each}

--- a/argus/backend/assets/TestRun/ResourcesInfo.svelte
+++ b/argus/backend/assets/TestRun/ResourcesInfo.svelte
@@ -54,6 +54,12 @@
                                                 Region: {resource.instance_info
                                                     .region}
                                             </li>
+                                            {#if resource.instance_info.shards_amount > 0}
+                                            <li>
+                                                Shards: {resource.instance_info
+                                                    .shards_amount}
+                                            </li>
+                                            {/if}
                                             <li>
                                                 Created at {timestampToISODate(
                                                     resource.instance_info

--- a/argus/db/cloud_types.py
+++ b/argus/db/cloud_types.py
@@ -1,5 +1,6 @@
 import ipaddress
 from enum import Enum
+from typing import Optional
 from pydantic.dataclasses import dataclass
 from pydantic import ValidationError, validator
 from argus.db.db_types import ArgusUDTBase
@@ -14,12 +15,14 @@ class CloudInstanceDetails(ArgusUDTBase):
     creation_time: int = 0
     termination_time: int = 0
     termination_reason: str = ""
+    shards_amount: Optional[int] = 0
+    _typename = "CloudInstanceDetails_v2"
 
     @classmethod
     def from_db_udt(cls, udt):
         return cls(provider=udt.provider, region=udt.region, public_ip=udt.public_ip, private_ip=udt.private_ip,
                    creation_time=udt.creation_time, termination_time=udt.termination_time,
-                   termination_reason=udt.termination_reason)
+                   termination_reason=udt.termination_reason, shards_amount=udt.shards_amount)
 
     @validator("public_ip")
     def valid_public_ip_address(cls, v):
@@ -91,6 +94,7 @@ class CloudResource(ArgusUDTBase):
     name: str
     state: str
     instance_info: CloudInstanceDetails
+    _typename = "CloudResource_v2"
 
     @classmethod
     def from_db_udt(cls, udt):

--- a/argus/db/interface.py
+++ b/argus/db/interface.py
@@ -43,6 +43,7 @@ class ArgusDatabase:
         str: cassandra.cqltypes.VarcharType.typename,
         UUID: cassandra.cqltypes.UUIDType.typename,
         Optional[str]: cassandra.cqltypes.VarcharType.typename,
+        Optional[int]: cassandra.cqltypes.IntegerType.typename,
     }
 
     _INSTANCE: Union['ArgusDatabase', Any] = None

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -345,7 +345,7 @@ class TestRun:
         "id": (UUID, "partition"),
     }
     _USING_RUNINFO = TestRunInfo
-    _TABLE_NAME = "test_runs_v3"
+    _TABLE_NAME = "test_runs_v3_shards_amount"
     _IS_TABLE_INITIALIZED = False
     _ARGUS_DB_INTERFACE = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ def preset_test_resources_setup_serialized():
             "creation_time": 7734,
             "termination_time": 0,
             "termination_reason": "",
+            "shards_amount": 0,
 
         },
         "region_name": ["us-east-1"],
@@ -177,7 +178,7 @@ def preset_test_resources():
     resources = TestResources()
 
     instance_info = CloudInstanceDetails(public_ip="1.1.1.1", region="us-east-1",
-                                         provider="aws", private_ip="10.10.10.1", creation_time=7734)
+                                         provider="aws", private_ip="10.10.10.1", creation_time=7734, shards_amount=10)
     resource = CloudResource(name="example_resource", state=ResourceState.RUNNING, instance_info=instance_info)
 
     resources.attach_resource(resource)
@@ -211,6 +212,7 @@ def preset_test_resources_serialized():
                 "creation_time": 7734,
                 "termination_time": 0,
                 "termination_reason": "",
+                "shards_amount": 10,
             }
         }],
         "leftover_resources": [{
@@ -224,6 +226,7 @@ def preset_test_resources_serialized():
                 "creation_time": 7734,
                 "termination_time": 0,
                 "termination_reason": "",
+                "shards_amount": 10,
             }
         }],
         "terminated_resources": [],
@@ -318,7 +321,7 @@ def completed_testrun(preset_test_resource_setup: TestResourcesSetup):  # pylint
             entropy = urandom(4).hex(sep=":", bytes_per_sep=1).split(":")
             random_ip = ".".join([str(int(byte, 16)) for byte in entropy])
             instance_details = CloudInstanceDetails(public_ip=random_ip, provider="aws", region="us-east-1",
-                                                    private_ip="10.10.10.1")
+                                                    private_ip="10.10.10.1", shards_amount=8)
             resource = CloudResource(name=f"{details.name}_{requested_node.instance_type}_{node_number}",
                                      state=ResourceState.RUNNING.value, instance_info=instance_details)
             resources.attach_resource(resource)

--- a/tests/test_testinfo.py
+++ b/tests/test_testinfo.py
@@ -66,7 +66,7 @@ def test_resources_setup_ctor_from_named_tuple(preset_test_resource_setup: TestR
     CloudNodeMapped = namedtuple("CloudNodeMapped", ["image_id", "instance_type", "node_amount", "post_behaviour"])
     CloudSetupMapped = namedtuple("CloudSetupMapped", ["backend", "db_node", "loader_node", "monitor_node"])
     CloudInstanceDetailsMapped = namedtuple("CloudInstanceDetailsMapped", [
-        "public_ip", "region", "provider", "private_ip", "creation_time", "termination_time", "termination_reason"])
+        "public_ip", "region", "provider", "private_ip", "creation_time", "termination_time", "termination_reason", "shards_amount"])
     ResourceSetupRow = namedtuple("ResourceSetupRow", ["sct_runner_host", "region_name", "cloud_setup"])
 
     db_node = CloudNodeMapped(image_id="ami-abcdef99", instance_type="spot",
@@ -80,7 +80,7 @@ def test_resources_setup_ctor_from_named_tuple(preset_test_resource_setup: TestR
 
     sct_runner_info = CloudInstanceDetailsMapped(public_ip="1.1.1.1", region="us-east-1", provider="aws",
                                                  private_ip="10.10.10.1", creation_time=7734, termination_time=0,
-                                                 termination_reason="")
+                                                 termination_reason="", shards_amount=0)
 
     mapped_setup = ResourceSetupRow(sct_runner_host=sct_runner_info, region_name=["us-east-1"], cloud_setup=cloud_setup)
 
@@ -152,11 +152,11 @@ def test_resources_attach_detach(preset_test_resources: TestResources):
 
 def test_resources_ctor_from_named_tuple(preset_test_resources):
     CloudInstanceDetailsMapped = namedtuple("CloudInstanceDetailsMapped", [
-        "provider", "region", "public_ip", "private_ip", "creation_time", "termination_time", "termination_reason"])
+        "provider", "region", "public_ip", "private_ip", "creation_time", "termination_time", "termination_reason", "shards_amount"])
     CloudResourceMapped = namedtuple("CloudResourceMapped", ["name", "state", "instance_info"])
     instance_info = CloudInstanceDetailsMapped(public_ip="1.1.1.1", region="us-east-1", provider="aws",
                                                private_ip="10.10.10.1", creation_time=7734, termination_time=0,
-                                               termination_reason="")
+                                               termination_reason="", shards_amount=10)
     resource = CloudResourceMapped(name="example_resource", state=ResourceState.RUNNING.value,
                                    instance_info=instance_info)
 


### PR DESCRIPTION
This adds a new optional field to CloudInstanceInfo, allowing to track
amount of shards used on the scylla node.

[Trello](https://trello.com/c/HJp3mPfQ/4389-add-shards-information-to-the-issue-template)