### PR TITLE
feature(argus.db): Screenshots support

### DIFF
--- a/argus/backend/assets/TestRun/Screenshots.svelte
+++ b/argus/backend/assets/TestRun/Screenshots.svelte
@@ -1,0 +1,94 @@
+<script>
+    import Fa from "svelte-fa";
+    import { faTimes, faFileDownload } from "@fortawesome/free-solid-svg-icons";
+    export let screenshots = [];
+
+    let selectedScreenshot = undefined;
+</script>
+
+<div class="d-flex p-2 align-items-center justify-content-center screenshots-holder">
+{#each screenshots as screenshot_url}
+        <div
+            class="screenshot-thumb mx-1 mb-2"
+            role="button"
+            style="background-image: url('{screenshot_url}')"
+            on:click={() => {
+                selectedScreenshot = screenshot_url;
+            }}
+        />
+{:else}
+    <div class="text-muted text-center py-2">No screenshots submitted!</div>
+{/each}
+</div>
+
+{#if selectedScreenshot}
+    <div class="screenshot-modal">
+        <div class="text-end">
+            <div class="d-inline-block screenshot-button">
+                <a href={selectedScreenshot} target="_blank"
+                    ><Fa color="#a0a0a0" icon={faFileDownload} /></a
+                >
+            </div>
+            <div
+                class="d-inline-block screenshot-button"
+                on:click={() => {
+                    selectedScreenshot = undefined;
+                }}
+            >
+                <Fa icon={faTimes} />
+            </div>
+        </div>
+        <div class="d-flex align-items-center justify-content-center my-2">
+            <img
+                class="screenshot-modal-image"
+                src={selectedScreenshot}
+                alt=""
+            />
+        </div>
+    </div>
+{/if}
+
+<style>
+    .screenshot-thumb {
+        border: solid 2px rgb(122, 122, 122);
+        border-radius: 4px;
+        width: 384px;
+        height: 384px;
+        background-size: cover;
+        background-repeat: no-repeat;
+    }
+
+    .screenshot-thumb:hover {
+        border: solid 2px rgb(209, 209, 209);
+    }
+
+    .screenshot-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+
+    .screenshot-button {
+        font-size: 32pt;
+        padding: 0 0.25rem;
+        color: rgb(138, 138, 138);
+        cursor: pointer;
+    }
+
+    .screenshot-button:hover {
+        color: white;
+    }
+
+    .screenshot-button:last-child {
+        padding-right: 1rem;
+    }
+
+    .screenshots-holder {
+        flex-wrap: wrap;
+    }
+</style>

--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -8,6 +8,7 @@
     import NemesisTable from "./NemesisTable.svelte";
     import ActivityTab from "./ActivityTab.svelte";
     import TestRunInfo from "./TestRunInfo.svelte";
+    import Screenshots from "./Screenshots.svelte";
     import TestRunComments from "./TestRunComments.svelte";
     import GithubIssues from "../Github/GithubIssues.svelte";
     import {
@@ -307,6 +308,14 @@
                 >
                 <button
                     class="nav-link"
+                    id="nav-screenshots-tab-{id}"
+                    data-bs-toggle="tab"
+                    data-bs-target="#nav-screenshots-{id}"
+                    type="button"
+                    role="tab"><i class="fas fa-images" /> Screenshots</button
+                >
+                <button
+                    class="nav-link"
                     id="nav-resources-tab-{id}"
                     data-bs-toggle="tab"
                     data-bs-target="#nav-resources-{id}"
@@ -378,6 +387,13 @@
                 role="tabpanel"
             >
                 <TestRunInfo {test_run} />
+            </div>
+            <div
+                class="tab-pane fade"
+                id="nav-screenshots-{id}"
+                role="tabpanel"
+            >
+                <Screenshots screenshots={test_run.screenshots} />
             </div>
             <div class="tab-pane fade" id="nav-resources-{id}" role="tabpanel">
                 <div

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,7 @@ def preset_test_results():
 
     results.add_event(event_severity="ERROR", event_message="Something went wrong...")
     results.add_nemesis(nemesis=nemesis)
+    results.add_screenshot("https://example.com/screenshot.jpg")
     results.status = TestStatus.FAILED
     return results
 
@@ -258,6 +259,8 @@ def preset_test_results_schema():
                              constraints=[]),
         "nemesis_data": ColumnInfo(name="nemesis_data", type=CollectionHint,
                                    value=CollectionHint(list[NemesisRunInfo]), constraints=[]),
+        "screenshots": ColumnInfo(name="screenshots", type=CollectionHint,
+                                  value=CollectionHint(list[str]), constraints=[]),
     }
 
 
@@ -287,6 +290,9 @@ def preset_test_results_serialized():
                 "end_time": 16001,
                 "stack_trace": "Something went wrong..."
             }
+        ],
+        "screenshots": [
+            "https://example.com/screenshot.jpg",
         ]
     }
 
@@ -348,7 +354,9 @@ def completed_testrun(preset_test_resource_setup: TestResourcesSetup):  # pylint
         nemesis_runs.append(nemesis)
 
     events = EventsBySeverity(severity="INFO", event_amount=66000, last_events=["Nothing here after all"])
-    results = TestResults(status=TestStatus.PASSED.value, nemesis_data=nemesis_runs, events=[events])
+    screenshots = ["https://example.com/screenshot.jpg"]
+    results = TestResults(status=TestStatus.PASSED.value, nemesis_data=nemesis_runs,
+                          events=[events], screenshots=screenshots)
 
     run_info = TestRunInfo(details=details, setup=setup, logs=logs, resources=resources, results=results)
 

--- a/tests/test_testinfo.py
+++ b/tests/test_testinfo.py
@@ -1,10 +1,9 @@
-import pytest
-from time import time
-from argus.db.testrun import TestDetails, TestResourcesSetup, TestResources, TestLogs, TestResults, TestInfoValueError
-from argus.db.db_types import TestStatus, PackageVersion, CollectionHint, ColumnInfo, NodeDescription, NemesisRunInfo, \
-    NemesisStatus
-from argus.db.cloud_types import BaseCloudSetupDetails, CloudInstanceDetails, ResourceState, CloudResource
+
 from collections import namedtuple
+import pytest
+from argus.db.testrun import TestDetails, TestResourcesSetup, TestResources, TestLogs, TestResults, TestInfoValueError
+from argus.db.db_types import TestStatus, NodeDescription, NemesisRunInfo, NemesisStatus
+from argus.db.cloud_types import CloudInstanceDetails, ResourceState, CloudResource
 
 
 def test_details_schema_dump(preset_test_details_schema: dict):
@@ -229,7 +228,7 @@ def test_results_ctor_from_named_tuple(preset_test_results, monkeypatch):
     monkeypatch.setattr("time.time", lambda: 16001)
     preset_test_results.nemesis_data[0].complete("Something went wrong...")
 
-    ResultsMapped = namedtuple("ResultsMapped", ["status", "events", "nemesis_data"])
+    ResultsMapped = namedtuple("ResultsMapped", ["status", "events", "nemesis_data", "screenshots"])
     EventsMapped = namedtuple("EventsMapped", ["severity", "event_amount", "last_events"])
     NemesisRunMapped = namedtuple("NemesisRunMapped",
                                   ["class_name", "name", "duration", "target_node", "status",
@@ -241,8 +240,8 @@ def test_results_ctor_from_named_tuple(preset_test_results, monkeypatch):
                                status=NemesisStatus.FAILED.value, start_time=16000, end_time=16001,
                                stack_trace="Something went wrong...")
     event = EventsMapped(severity="ERROR", event_amount=1, last_events=["Something went wrong..."])
-
-    row = ResultsMapped(status=TestStatus.FAILED.value, events=[event], nemesis_data=[nemesis])
+    screeshots = ["https://example.com/screenshot.jpg"]
+    row = ResultsMapped(status=TestStatus.FAILED.value, events=[event], nemesis_data=[nemesis], screenshots=screeshots)
 
     new_test_result = TestResults.from_db_row(row)
 


### PR DESCRIPTION
This PR adds suport for submitting screenshots alongside test run.
Accessible as part of TestRunResults, they are represented as a list of
strings, each string implicitly being a URL pointing to the location of
the screenshot. Also, it adds a screenshot viewer to the TestRun card, allowing to
view on a grid screenshots submitted as part of the run. Clicking the
screenshot would open a modal window in full size, allowing viewing and
downloading.

[Trello](https://trello.com/c/CjxNoE9l/4414-add-screenshots-links-to-the-details-of-the-run)
[Demo](https://user-images.githubusercontent.com/7761415/151021172-9816667c-8e77-4f99-b0ad-0b0c960da887.mp4)