### PR TITLE
feature(argus.db): Investigation status 

### DIFF
--- a/argus/backend/api.py
+++ b/argus/backend/api.py
@@ -465,6 +465,29 @@ def test_run_change_status():
     return jsonify(res)
 
 
+@bp.route("/test_run/change_investigation_status", methods=["POST"])
+@login_required
+def test_run_change_investigation_status():
+    res = {
+        "status": "ok"
+    }
+    try:
+        if not request.is_json:
+            raise Exception(
+                "Content-Type mismatch, expected application/json, got:", request.content_type)
+        request_payload = request.get_json()
+        service = ArgusService()
+        res["response"] = service.toggle_test_investigation_status(request_payload)
+    except Exception as exc:
+        LOGGER.error("Something happened during request %s", request)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
 @bp.route("/test_run/change_assignee", methods=["POST"])
 @login_required
 def test_run_change_assignee():

--- a/argus/backend/assets/Common/TestStatus.js
+++ b/argus/backend/assets/Common/TestStatus.js
@@ -12,6 +12,25 @@ export const TestStatusChangeable = {
     ABORTED: "aborted",
 };
 
+
+export const TestInvestigationStatus = {
+    INVESTIGATED: "investigated",
+    NOT_INVESTIGATED: "not_investigated",
+    IN_PROGRESS: "in_progress",
+};
+
+export const InvestigationButtonCSSClassMap = {
+    "in_progress": "btn-warning",
+    "not_investigated": "btn-danger",
+    "investigated": "btn-success",
+};
+
+export const TestInvestigationStatusStrings = {
+    "in_progress": "In progress",
+    "not_investigated": "Not Investigated",
+    "investigated": "Investigated",
+}
+
 export const StatusBackgroundCSSClassMap = {
     "created": "bg-info",
     "running": "bg-warning",

--- a/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
@@ -10,7 +10,7 @@
     import ReleaseGithubIssues from "./ReleaseGithubIssues.svelte";
     import TestPopoutSelector from "./TestPopoutSelector.svelte";
     import { sendMessage } from "../Stores/AlertStore";
-    let clickedTests = [];
+    let clickedTests = {};
 
     const handleTestClick = function (e) {
         if (e.detail.start_time == 0) {
@@ -18,14 +18,19 @@
             return;
         }
 
-        if (clickedTests.findIndex((val) => val.name == e.detail.name) == -1) {
-            clickedTests.push(e.detail);
+        if (!clickedTests[e.detail.name]) {
+            clickedTests[e.detail.name] = e.detail;
+        } else {
+            delete clickedTests[e.detail.name];
             clickedTests = clickedTests;
         }
     };
 
     const handleDeleteRequest = function(ev) {
-        clickedTests = clickedTests.filter(val => val.name != ev.detail.name);
+        if (clickedTests[ev.detail.name]) {
+            delete clickedTests[ev.detail.name];
+            clickedTests = clickedTests;
+        }
     };
 </script>
 
@@ -33,32 +38,6 @@
     <div class="row mb-2">
         <div class="col-8">
             <h1 class="display-1">{releaseData.release.name}</h1>
-            <h3 class="text-muted">
-                {releaseData.release.pretty_name ?? "No name"}
-            </h3>
-            <div class="input-group user-select-all">
-                <span class="input-group-text">Github</span>
-                <input
-                    class="form-control"
-                    type="text"
-                    disabled
-                    value={releaseData.release.github_repo_url}
-                />
-                <a
-                    href={releaseData.release.github_repo_url}
-                    target="_blank"
-                    class="btn btn-dark"><Fa icon={faGithub} /></a
-                >
-                <a
-                    href="{releaseData.release
-                        .github_repo_url}/issues/new/choose"
-                    target="_blank"
-                    class="btn btn-success"><Fa icon={faBug} /></a
-                >
-            </div>
-            <p class="text-muted">
-                {releaseData.release.description ?? "No description provided."}
-            </p>
         </div>
     </div>
     <div class="row mb-2">
@@ -68,6 +47,7 @@
                 DisplayItem={ChartStats}
                 showTestMap={true}
                 horizontal={true}
+                bind:clickedTests={clickedTests}
                 on:testClick={handleTestClick}
             />
         </div>
@@ -78,13 +58,6 @@
                 releaseName={releaseData.release.name}
             />
         </div>
-    </div>
-    <div class="row mb-2">
-        <ReleaseGithubIssues
-            release_id={releaseData.release.id}
-            release_name={releaseData.release.name}
-            tests={releaseData.tests}
-        />
     </div>
     <div class="row mb-2">
         <ReleaseActivity releaseName={releaseData.release.name} />

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -1,19 +1,24 @@
 <script>
     import Fa from "svelte-fa";
     import { StatusCSSClassMap } from "../Common/TestStatus";
+    import { timestampToISODate } from "../Common/DateUtils";
     import { createEventDispatcher } from "svelte";
     import { Base64 } from "js-base64";
     import {
         faCircle,
-        faTrash,
+        faTimes,
+        faAngleDoubleDown,
+        faBug,
+        faHammer,
         faExternalLinkSquareAlt,
     } from "@fortawesome/free-solid-svg-icons";
+    import { faGithub } from "@fortawesome/free-brands-svg-icons"
     export let tests = [];
     export let releaseName = "";
     let encodedState = "e30";
     $: encodedState = Base64.encode(
         JSON.stringify(
-            tests.reduce((acc, val) => {
+            Object.values(tests).reduce((acc, val) => {
                 acc[`${releaseName}/${val.name}`] = {
                     test: val.name,
                     release: releaseName,
@@ -32,27 +37,83 @@
     };
 </script>
 
-{#if tests.length > 0}
+{#if Object.values(tests).length > 0}
     <div class="d-flex flex-column">
-        <ul class="list-group" style="height: 378px; overflow-y: scroll;">
-            {#each tests as test (test.name)}
-                <li class="list-group-item d-flex align-items-center">
-                    <div class="{StatusCSSClassMap[test.status]} me-3">
-                        <Fa icon={faCircle} />
-                    </div>
-                    <div class="d-flex flex-column">
-                        <span>{test.name}</span>
-                        <span class="text-muted" style="font-size: 0.75em"
-                            >{new Date(
-                                test.start_time * 1000
-                            ).toISOString()}</span
+        <ul class="list-group" style="height: 960px; overflow-y: scroll;">
+            {#each Object.values(tests) as test (test.name)}
+                <li class="list-group-item">
+                    <div class="d-flex align-items-center">
+                        <div class="d-flex flex-column">
+                            <span class="fw-bold">{test.name}</span>
+                        </div>
+                        <button
+                            class="ms-auto btn btn-secondary btn-sm"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapse-builds-{test.name}"
+                            title="Latest builds"
+                            ><Fa icon={faAngleDoubleDown} /></button
+                        >
+                        <button
+                            class="ms-1 btn btn-secondary btn-sm"
+                            title="Dismiss"
+                            on:click={() => handleTrashClick(test.name)}
+                            ><Fa icon={faTimes} /></button
                         >
                     </div>
-                    <button
-                        class="ms-auto btn btn-danger btn-sm"
-                        on:click={() => handleTrashClick(test.name)}
-                        ><Fa icon={faTrash} /></button
-                    >
+                    <div class="collapse show" id="collapse-builds-{test.name}">
+                        <ul class="list-unstyled">
+                            {#each test.last_runs as run, idx}
+                                <li class="my-1" class:border-top={idx > 0}>
+                                    <div class="d-flex align-items-center">
+                                        <div
+                                            class="ms-2 {StatusCSSClassMap[
+                                                run.status
+                                            ]}"
+                                        >
+                                            <Fa icon={faCircle} />
+                                        </div>
+                                        <div class="ms-2">
+                                            <a
+                                                target="_blank"
+                                                href="{run.build_job_url}"
+                                                class="link-dark"
+                                            >
+                                                #{run.build_number}
+                                            </a>
+                                        </div>
+                                        <div class="ms-auto text-muted small-text">
+                                            {timestampToISODate(
+                                                run.start_time * 1000
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div
+                                    >
+                                        <ul class="list-unstyled">
+                                            {#each run.issues as issue}
+                                                <li class="ms-3 d-flex align-items-center">
+                                                    <div class="ms-1">
+                                                        <Fa icon={faGithub} />
+                                                    </div>
+                                                    <div class="ms-1">
+                                                        <a
+                                                            target="_blank"
+                                                            href="{issue.url}"
+                                                        >
+                                                            {issue.title}
+                                                        </a>
+                                                    </div>
+                                                    <div class="ms-auto text-muted">
+                                                        {issue.owner}/{issue.repo}#{issue.issue_number}
+                                                    </div>
+                                                </li>
+                                            {/each}
+                                        </ul>
+                                    </div>
+                                </li>
+                            {/each}
+                        </ul>
+                    </div>
                 </li>
             {/each}
         </ul>
@@ -60,10 +121,13 @@
             href="/run_dashboard?state={encodedState}"
             class="btn btn-primary"
             target="_blank"
-            >Open work area <Fa icon={faExternalLinkSquareAlt} /></a
+            >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
         >
     </div>
 {/if}
 
 <style>
+    .small-text {
+        font-size: 0.75em;
+    }
 </style>

--- a/argus/backend/assets/Stats/ChartStats.svelte
+++ b/argus/backend/assets/Stats/ChartStats.svelte
@@ -40,4 +40,4 @@
     });
 
 </script>
-<canvas bind:this={chartCanvas} />
+<canvas bind:this={chartCanvas} width="112px"/>

--- a/argus/backend/assets/Stats/ReleaseStats.svelte
+++ b/argus/backend/assets/Stats/ReleaseStats.svelte
@@ -9,6 +9,7 @@
     export let showTestMap = false;
     export let showReleaseStats = true;
     export let horizontal = false;
+    export let clickedTests = {};
     const dispatch = createEventDispatcher();
     const releaseStatsDefault = {
         created: 0,
@@ -18,6 +19,7 @@
         aborted: 0,
         lastStatus: "unknown",
         disabled: true,
+        limited: !showTestMap,
         groups: {},
         tests: {},
         total: -1,
@@ -28,7 +30,7 @@
     $: dispatch("statsUpdate", { stats: releaseStats });
 </script>
 
-<div class="d-flex justify-content-center align-items-center" class:flex-column={!horizontal}>
+<div class="d-flex justify-content-center" class:flex-column={!horizontal} class:align-items-center={!horizontal}>
     {#if releaseStats?.total > 0}
         {#if showReleaseStats}
             <div class="w-100">
@@ -37,7 +39,7 @@
         {/if}
         {#if showTestMap}
             <div>
-                <svelte:component this={TestMapItem} stats={releaseStats} on:testClick />
+                <svelte:component this={TestMapItem} stats={releaseStats} bind:clickedTests={clickedTests} on:testClick />
             </div>
         {/if}
     {:else if releaseStats?.total == -1}

--- a/argus/backend/assets/Stats/TestMapStats.svelte
+++ b/argus/backend/assets/Stats/TestMapStats.svelte
@@ -1,7 +1,21 @@
 <script>
     import { createEventDispatcher } from "svelte";
+    import Fa from "svelte-fa";
+    import {
+        faSearch,
+        faEyeSlash,
+        faEye,
+        faBug,
+        faAngleRight,
+    } from "@fortawesome/free-solid-svg-icons";
 
-    import { StatusBackgroundCSSClassMap } from "../Common/TestStatus";
+    import {
+        StatusBackgroundCSSClassMap,
+        TestInvestigationStatus,
+        TestInvestigationStatusStrings,
+        TestStatus,
+    } from "../Common/TestStatus";
+    export let clickedTests = {};
     export let stats = {
         tests: {
             example: {
@@ -10,42 +24,121 @@
             },
         },
     };
+
+    const investigationStatusIcon = {
+        in_progress: faEye,
+        not_investigated: faEyeSlash,
+        investigated: faSearch,
+    };
+
     const dispatch = createEventDispatcher();
 
-    const handleTestClick = function (e) {
-        let data = e.target.dataset;
-        if (data.argusTestStartTime == 0) return;
+    const handleTestClick = function (name, test) {
+        if (test.start_time == 0) return;
         dispatch("testClick", {
-            name: data.argusTestName,
-            status: data.argusTestStatus,
-            start_time: data.argusTestStartTime,
+            name: name,
+            status: test.status,
+            start_time: test.start_time,
+            last_runs: test.last_runs,
         });
+    };
+
+    const filterTestsForGroup = function (groupName, tests) {
+        return Object.values(tests)
+            .filter((test) => test.group == groupName)
+            .reduce((tests, test) => {
+                tests[test.name] = test;
+                return tests;
+            }, {});
     };
 </script>
 
-<div class="mt-3 d-flex flex-wrap">
-    {#each Object.keys(stats.tests) as test}
-        <div
-            on:click|self={handleTestClick}
-            class:status-block-active={stats.tests[test].start_time != 0}
-            class="d-inline-block border status-block {StatusBackgroundCSSClassMap[stats.tests[test].status]}"
-            data-argus-test-name={test}
-            data-argus-test-status={stats.tests[test].status}
-            data-argus-test-start-time={stats.tests[test].start_time}
-            title={test}
-        />
-    {/each}
-</div>
+{#each Object.entries(stats.groups) as [groupName, group] (groupName)}
+    <div>
+        <h5>{groupName}</h5>
+        <div class="my-2 d-flex flex-wrap">
+            {#each Object.entries(filterTestsForGroup(groupName, stats.tests)) as [testName, test] (testName)}
+                <div
+                    on:click={() => {
+                        handleTestClick(testName, test);
+                    }}
+                    class:status-block-active={test.start_time != 0}
+                    class="d-inline-block border status-block {StatusBackgroundCSSClassMap[
+                        test.status
+                    ]}"
+                >
+                    <div
+                        class="position-absolute status-block-popup shadow p-1"
+                    >
+                        {testName}
+                    </div>
+                    <div
+                        class="d-flex h-100 align-items-center justify-content-center p-2 status-block-inner"
+                    >
+                        {#if clickedTests[testName]}
+                            <Fa
+                                color="#fff"
+                                icon={faAngleRight}
+                            />
+                        {/if}
+                        {#if test.investigation_status && (test.status != TestStatus.PASSED || test.investigation_status != TestInvestigationStatus.NOT_INVESTIGATED)}
+                            <div
+                                class="p-1"
+                                title="Investigation: {TestInvestigationStatusStrings[
+                                    test.investigation_status
+                                ]}"
+                            >
+                                <Fa
+                                    color="#fff"
+                                    icon={investigationStatusIcon[
+                                        test.investigation_status
+                                    ]}
+                                />
+                            </div>
+                        {/if}
+                        {#if test.hasBugReport}
+                            <div class="p-1" title="Has a bug report">
+                                <Fa color="#fff" icon={faBug} />
+                            </div>
+                        {/if}
+                    </div>
+                </div>
+            {:else}
+                <div class="text-muted my-2">No tests for this group</div>
+            {/each}
+        </div>
+    </div>
+{/each}
 
 <style>
     .status-block {
         cursor: help;
-        width: 32px;
-        height: 32px;
+        width: 64px;
+        height: 64px;
+        position: relative;
     }
 
     .status-block-active:hover {
-        opacity: 0.5;
         cursor: pointer;
+    }
+
+    .status-block-active:hover > .status-block-inner {
+        border: 2px solid black;
+    }
+
+    .status-block-popup {
+        display: none;
+        width: 256px;
+        font-size: 0.9em;
+        background-color: white;
+        border: solid 1px white;
+        font-family: monospace;
+        border-radius: 8px;
+        top: -2.5em;
+        z-index: 999;
+    }
+
+    .status-block:hover > .status-block-popup {
+        display: block;
     }
 </style>

--- a/argus/backend/assets/release-page.js
+++ b/argus/backend/assets/release-page.js
@@ -8,7 +8,7 @@ releaseElements.forEach(el => {
         target: el.querySelector("div.release-stats"),
         props: {
             releaseName: el.dataset.argusReleaseName,
-            showTestMap: true
+            showTestMap: false
         }
     });
     registeredApps.push(app);

--- a/argus/backend/event_processors.py
+++ b/argus/backend/event_processors.py
@@ -9,6 +9,10 @@ def event_process_status_changed(event: dict) -> dict:
     return event["message"].format(**event)
 
 
+def event_process_investigation_status_changed(event: dict) -> dict:
+    return event["message"].format(**event)
+
+
 def event_process_assignee_changed(event: dict) -> dict:
     return event["message"].format(**event)
 
@@ -22,4 +26,5 @@ EVENT_PROCESSORS = {
     ArgusEventTypes.TestRunStatusChanged: event_process_status_changed,
     ArgusEventTypes.TestRunCommentPosted: event_process_posted_comment,
     ArgusEventTypes.TestRunIssueAdded: event_process_issue_added,
+    ArgusEventTypes.TestRunInvestigationStatusChanged: event_process_investigation_status_changed,
 }

--- a/argus/backend/models.py
+++ b/argus/backend/models.py
@@ -107,6 +107,7 @@ class ArgusTestRunComment(Model):
 class ArgusEventTypes(str, Enum):
     AssigneeChanged = "ARGUS_ASSIGNEE_CHANGE"
     TestRunStatusChanged = "ARGUS_TEST_RUN_STATUS_CHANGE"
+    TestRunInvestigationStatusChanged = "ARGUS_TEST_RUN_INVESTIGATION_STATUS_CHANGE"
     TestRunCommentPosted = "ARGUS_TEST_RUN_COMMENT_POSTED"
     TestRunIssueAdded = "ARGUS_TEST_RUN_ISSUE_ADDED"
 

--- a/argus/backend/templates/release_dashboard.html.j2
+++ b/argus/backend/templates/release_dashboard.html.j2
@@ -13,7 +13,7 @@ Release: {{ release_name }}
 {% endblock javascripts %}
 
 {% block body %}
-    <div class="container">
+    <div class="container-fluid my-4">
         <div id="releaseDashboard"></div>
     </div>
 {% endblock %}

--- a/argus/backend/templates/releases.html.j2
+++ b/argus/backend/templates/releases.html.j2
@@ -10,10 +10,10 @@ Releases
 {% endblock javascripts %}
 
 {% block body %}
-    <div class="container">
-        <div class="row">
+    <div class="container my-2">
+        <div class="row justify-content-center">
         {% for release in releases %}
-            <div class="col card m-1 release-card" data-argus-release-name="{{ release.name }}">
+            <div class="col-3 card m-1 release-card" data-argus-release-name="{{ release.name }}">
                 <div class="card-body">
                         <h3 class="card-title">{{ release.name if not release.pretty_name else release.pretty_name }}</h3>
                         <p class="card-subtitle text-muted">{{ release.description if release.description else "No description provided" }}</p>

--- a/argus/db/db_types.py
+++ b/argus/db/db_types.py
@@ -68,6 +68,12 @@ class TestStatus(str, Enum):
     ABORTED = "aborted"
 
 
+class TestInvestigationStatus(str, Enum):
+    NOT_INVESTIGATED = "not_investigated"
+    IN_PROGRESS = "in_progress"
+    INVESTIGATED = "investigated"
+
+
 @dataclass(init=True, repr=True)
 class NemesisRunInfo(ArgusUDTBase):
     class_name: str

--- a/tests/test_e2e_argus.py
+++ b/tests/test_e2e_argus.py
@@ -3,6 +3,7 @@ import logging
 from uuid import uuid4
 import pytest
 from argus.db.testrun import TestRun, TestRunInfo
+from argus.db.db_types import TestInvestigationStatus
 from argus.db.interface import ArgusDatabase
 
 LOGGER = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ class TestEndToEnd:
         TestRun.set_argus(argus_database)
         test_id = uuid4()
         test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
-                           run_info=completed_testrun)
+                           run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
 
         test_run.save()
 
@@ -33,7 +34,7 @@ class TestEndToEnd:
         TestRun.set_argus(argus_database)
         test_id = uuid4()
         test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
-                           run_info=completed_testrun)
+                           run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
 
         test_run.save()
 
@@ -47,7 +48,7 @@ class TestEndToEnd:
         TestRun.set_argus(argus_database)
         test_id = uuid4()
         test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
-                           run_info=completed_testrun)
+                           run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
         test_run.save()
 
         resource = choice(test_run.run_info.resources.leftover_resources)


### PR DESCRIPTION
This PR adds an investigation status field to main TestRun object
allowing to track whether or not run was investigated / triaged after
completion.

Also, a new release dashboard has been added. This dashboard sorts tests by their group, shows issue /
investigation icons on each test if their status is not positive and
allows to quickly see last builds and open issues for each test by
clicking on them.
Image:
![image](https://user-images.githubusercontent.com/7761415/151364084-a02fb5aa-38ea-4ffd-92fd-a05df5fd8075.png)

[Trello](https://trello.com/c/ecG2a9kz/4497-add-investigated-test-run-status)
