### PR TITLE
fix(argus.db.testrun): TestResources from_row constructor rework

### DIFF
--- a/argus/db/cloud_types.py
+++ b/argus/db/cloud_types.py
@@ -92,7 +92,7 @@ class ResourceState(str, Enum):
 @dataclass(init=True, repr=True)
 class CloudResource(ArgusUDTBase):
     name: str
-    state: str
+    state: ResourceState
     instance_info: CloudInstanceDetails
     _typename = "CloudResource_v2"
 

--- a/argus/db/interface.py
+++ b/argus/db/interface.py
@@ -15,6 +15,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 
 from argus.db.config import BaseConfig, FileConfig
 from argus.db.db_types import ColumnInfo, CollectionHint, ArgusUDTBase
+from argus.db.cloud_types import ResourceState
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class ArgusDatabase:
         float: cassandra.cqltypes.FloatType.typename,
         str: cassandra.cqltypes.VarcharType.typename,
         UUID: cassandra.cqltypes.UUIDType.typename,
+        ResourceState: cassandra.cqltypes.VarcharType.typename,
         Optional[str]: cassandra.cqltypes.VarcharType.typename,
         Optional[int]: cassandra.cqltypes.IntegerType.typename,
     }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 
 setup(
     name='argus',
-    version='0.5.4',
+    version='0.5.4.1',
     packages=["argus.db", "argus.backend"],
     include_package_data=True,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,7 +329,7 @@ def completed_testrun(preset_test_resource_setup: TestResourcesSetup):  # pylint
             instance_details = CloudInstanceDetails(public_ip=random_ip, provider="aws", region="us-east-1",
                                                     private_ip="10.10.10.1", shards_amount=8)
             resource = CloudResource(name=f"{details.name}_{requested_node.instance_type}_{node_number}",
-                                     state=ResourceState.RUNNING.value, instance_info=instance_details)
+                                     state=ResourceState.RUNNING, instance_info=instance_details)
             resources.attach_resource(resource)
             created_resources.append(resource)
 
@@ -347,7 +347,7 @@ def completed_testrun(preset_test_resource_setup: TestResourcesSetup):  # pylint
             name="disrupt_something",
             duration=42,
             target_node=node_description,
-            status=NemesisStatus.SUCCEEDED.value,
+            status=NemesisStatus.SUCCEEDED,
             start_time=int(time()),
             end_time=int(time() + 30),
         )
@@ -355,7 +355,7 @@ def completed_testrun(preset_test_resource_setup: TestResourcesSetup):  # pylint
 
     events = EventsBySeverity(severity="INFO", event_amount=66000, last_events=["Nothing here after all"])
     screenshots = ["https://example.com/screenshot.jpg"]
-    results = TestResults(status=TestStatus.PASSED.value, nemesis_data=nemesis_runs,
+    results = TestResults(status=TestStatus.PASSED, nemesis_data=nemesis_runs,
                           events=[events], screenshots=screenshots)
 
     run_info = TestRunInfo(details=details, setup=setup, logs=logs, resources=resources, results=results)


### PR DESCRIPTION
Due to the way TestResources.from_row worked before, it was possible to
end up with duplicate objects of the same resource, because the
constructor was reinstanting each object from 3 arrays, 2 of which
contained references to the first array. This is now fixed.