### PR TITLE
fix(ReleaseActivity.svelte): Replace placeholder raw_events value

### DIFF
--- a/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
@@ -15,7 +15,7 @@
     export let releaseName = undefined;
     let activity = {
         events: {},
-        raw_events: {},
+        raw_events: [],
         release_name: "",
     };
 


### PR DESCRIPTION
This prevents errors when release activity wasn't fetched in time.