### PR TITLE
improvement(WorkArea.svelte): Limit work area sidebar height

### DIFF
--- a/argus/backend/assets/WorkArea/WorkArea.svelte
+++ b/argus/backend/assets/WorkArea/WorkArea.svelte
@@ -101,7 +101,7 @@
 <div class="container-fluid bg-light">
     <div class="row p-4" id="dashboard-main">
         <div
-            class="col-3 p-0 py-4 min-vh-100 me-3 border rounded shadow-sm bg-white"
+            class="col-3 p-0 py-4 me-3 border rounded shadow-sm bg-white"
             id="run-sidebar"
         >
             <div class="p-2">
@@ -128,5 +128,10 @@
 <style>
     .bg-white {
         background-color: #fff;
+    }
+
+    #run-sidebar {
+        height: 960px;
+        overflow-y: scroll;
     }
 </style>


### PR DESCRIPTION
This commit adds a fixed 960px height for the sidebar in the work area
intended to improve user experience when selecting multiple tests
without them having to scroll constantly up or down each time they
select a test.

[Trello](https://trello.com/c/9Csu1cap/4410-test-runs-panel-should-be-anchored-to-the-viewport)