### PR TITLE
improvement(argus.db.db_types): Add TERMINATED Nemesis state

### DIFF
--- a/argus/db/db_types.py
+++ b/argus/db/db_types.py
@@ -58,6 +58,7 @@ class NemesisStatus(str, Enum):
     FAILED = "failed"
     SKIPPED = "skipped"
     SUCCEEDED = "succeeded"
+    TERMINATED = "terminated"
 
 
 class TestStatus(str, Enum):


### PR DESCRIPTION
Adds a new terminated state which is used when a nemesis is terminated
by the test framework due to various reasons.

[Trello](https://trello.com/c/eeLFaug8/4567-create-terminated-state-for-nemesis)